### PR TITLE
Add projects support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform-provider-spinnaker
 *.tf
 *.log
 pipelines
+*.exe

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ resource "spinnaker_application" "my_app" {
 resource "spinnaker_pipeline" "terraform_example" {
     application = "${spinnaker_application.my_app.application}"
     name = "Example Pipeline"
-    pipeline = file("pipelines/example.json")
+    pipeline = "${file("pipelines/example.json")}"
 }
 ```
 
@@ -80,7 +80,7 @@ resource "spinnaker_application" "my_app" {
 resource "spinnaker_pipeline" "terraform_example" {
     application = "${spinnaker_application.my_app.application}"
     name = "Example Pipeline"
-    pipeline = file("pipelines/example.json")
+    pipeline = "${file("pipelines/example.json")}"
 }
 ```
 
@@ -98,8 +98,8 @@ resource "spinnaker_pipeline" "terraform_example" {
 resource "spinnaker_project" "my_project" {
     project = "projecttest"
     email = "howdy@email.com"
-    applications = file("projects/my_project/applications.json")
-    pipelines = file("projects/my_project/pipelines.json")
+    applications = "${file("projects/my_project/applications.json")}"
+    pipelines = "${file("projects/my_project/pipelines.json")}"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,3 +89,23 @@ resource "spinnaker_pipeline" "terraform_example" {
 * `application` - Application name
 * `name` - Pipeline name
 * `pipeline` - Pipeline JSON in string format, example `file(pipelines/example.json)`
+
+### `spinnaker_project`
+
+#### Example Usage
+
+```
+resource "spinnaker_project" "my_project" {
+    project = "projecttest"
+    email = "howdy@email.com"
+    applications = file("projects/my_project/applications.json")
+    pipelines = file("projects/my_project/pipelines.json")
+}
+```
+
+#### Argument Reference
+
+* `project` - Project name
+* `email` - Owner Name
+* `applications` - Applications to be included in the project
+* `pipelines` - Application Pipelines to be included in the project

--- a/spinnaker/api/api.go
+++ b/spinnaker/api/api.go
@@ -1,0 +1,31 @@
+package api
+
+func taskCompleted(task map[string]interface{}) bool {
+	taskStatus, exists := task["status"]
+	if !exists {
+		return false
+	}
+
+	COMPLETED := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED", "TERMINAL", "FAILED_CONTINUE"}
+	for _, status := range COMPLETED {
+		if taskStatus == status {
+			return true
+		}
+	}
+	return false
+}
+
+func taskSucceeded(task map[string]interface{}) bool {
+	taskStatus, exists := task["status"]
+	if !exists {
+		return false
+	}
+
+	SUCCESSFUL := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED"}
+	for _, status := range SUCCESSFUL {
+		if taskStatus == status {
+			return true
+		}
+	}
+	return false
+}

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -77,7 +77,7 @@ func CreateApplication(client *gate.GatewayClient, applicationName, email string
 	return nil
 }
 
-func DeleteAppliation(client *gate.GatewayClient, applicationName string) error {
+func DeleteApplication(client *gate.GatewayClient, applicationName string) error {
 	jobSpec := map[string]interface{}{
 		"type": "deleteApplication",
 		"application": map[string]interface{}{

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -103,33 +103,3 @@ func DeleteApplication(client *gate.GatewayClient, applicationName string) error
 
 	return nil
 }
-
-func taskCompleted(task map[string]interface{}) bool {
-	taskStatus, exists := task["status"]
-	if !exists {
-		return false
-	}
-
-	COMPLETED := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED", "TERMINAL", "FAILED_CONTINUE"}
-	for _, status := range COMPLETED {
-		if taskStatus == status {
-			return true
-		}
-	}
-	return false
-}
-
-func taskSucceeded(task map[string]interface{}) bool {
-	taskStatus, exists := task["status"]
-	if !exists {
-		return false
-	}
-
-	SUCCESSFUL := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED"}
-	for _, status := range SUCCESSFUL {
-		if taskStatus == status {
-			return true
-		}
-	}
-	return false
-}

--- a/spinnaker/api/project.go
+++ b/spinnaker/api/project.go
@@ -103,35 +103,3 @@ func DeleteProject(client *gate.GatewayClient, projectName string) error {
 
 	return nil
 }
-
-// todo: consider abstracting away to be shared with api/application
-func taskCompleted(task map[string]interface{}) bool {
-	taskStatus, exists := task["status"]
-	if !exists {
-		return false
-	}
-
-	COMPLETED := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED", "TERMINAL", "FAILED_CONTINUE"}
-	for _, status := range COMPLETED {
-		if taskStatus == status {
-			return true
-		}
-	}
-	return false
-}
-
-// todo: consider abstracting away to be shared with api/application
-func taskSucceeded(task map[string]interface{}) bool {
-	taskStatus, exists := task["status"]
-	if !exists {
-		return false
-	}
-
-	SUCCESSFUL := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED"}
-	for _, status := range SUCCESSFUL {
-		if taskStatus == status {
-			return true
-		}
-	}
-	return false
-}

--- a/spinnaker/api/project.go
+++ b/spinnaker/api/project.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	gate "github.com/spinnaker/spin/cmd/gateclient"
+)
+
+func GetProject(client *gate.GatewayClient, projectName string, dest interface{}) error {
+	// todo: find what can be used to get projects
+	project, resp, err := client.ProjectControllerApi.GetProjectUsingGET(client.Context, projectName, map[string]interface{}{})
+	if resp != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Project '%s' not found\n", projectName)
+		} else if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Encountered an error getting project, status code: %d\n", resp.StatusCode)
+		}
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if err := mapstructure.Decode(project, dest); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CreateProject(client *gate.GatewayClient, projectName, email string) error {
+
+	project := map[string]interface{}{
+		"name":  projectName,
+		"email": email,
+	}
+
+	createProjectTask := map[string]interface{}{
+		"job":         []interface{}{map[string]interface{}{"type": "upsertProject", "project": project}},
+		"project":     projectName,
+		"description": fmt.Sprintf("Create Project: %s", projectName),
+	}
+
+	ref, _, err := client.TaskControllerApi.TaskUsingPOST1(client.Context, createProjectTask)
+	if err != nil {
+		return err
+	}
+
+	toks := strings.Split(ref["ref"].(string), "/")
+	id := toks[len(toks)-1]
+
+	task, resp, err := client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+	attempts := 0
+	for (task == nil || !taskCompleted(task)) && attempts < 5 {
+		toks := strings.Split(ref["ref"].(string), "/")
+		id := toks[len(toks)-1]
+
+		task, resp, err = client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+		attempts++
+		time.Sleep(time.Duration(attempts*attempts) * time.Second)
+	}
+
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("Encountered an error saving project, status code: %d\n", resp.StatusCode)
+	}
+	if !taskSucceeded(task) {
+		return fmt.Errorf("Encountered an error saving project, task output was: %v\n", task)
+	}
+
+	return nil
+}
+
+func DeleteProject(client *gate.GatewayClient, projectName string) error {
+	jobSpec := map[string]interface{}{
+		"type": "deleteProject",
+		"project": map[string]interface{}{
+			"name": projectName,
+		},
+	}
+
+	deleteProjectTask := map[string]interface{}{
+		"job":         []interface{}{jobSpec},
+		"project":     projectName,
+		"description": fmt.Sprintf("Delete Project: %s", projectName),
+	}
+
+	_, resp, err := client.TaskControllerApi.TaskUsingPOST1(client.Context, deleteProjectTask)
+
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Encountered an error deleting project, status code: %d\n", resp.StatusCode)
+	}
+
+	return nil
+}
+
+// todo: consider abstracting away to be shared with api/application
+func taskCompleted(task map[string]interface{}) bool {
+	taskStatus, exists := task["status"]
+	if !exists {
+		return false
+	}
+
+	COMPLETED := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED", "TERMINAL", "FAILED_CONTINUE"}
+	for _, status := range COMPLETED {
+		if taskStatus == status {
+			return true
+		}
+	}
+	return false
+}
+
+// todo: consider abstracting away to be shared with api/application
+func taskSucceeded(task map[string]interface{}) bool {
+	taskStatus, exists := task["status"]
+	if !exists {
+		return false
+	}
+
+	SUCCESSFUL := [...]string{"SUCCEEDED", "STOPPED", "SKIPPED"}
+	for _, status := range SUCCESSFUL {
+		if taskStatus == status {
+			return true
+		}
+	}
+	return false
+}

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -19,6 +19,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"spinnaker_application": resourceApplication(),
 			"spinnaker_pipeline":    resourcePipeline(),
+			"spinnaker_project":     resourceProject(),
 		},
 		ConfigureFunc: providerConfigureFunc,
 	}

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -68,7 +68,7 @@ func resourceApplicationDelete(data *schema.ResourceData, meta interface{}) erro
 	client := clientConfig.client
 	applicationName := data.Get("application").(string)
 
-	return api.DeleteAppliation(client, applicationName)
+	return api.DeleteApplication(client, applicationName)
 }
 
 func resourceApplicationExists(data *schema.ResourceData, meta interface{}) (bool, error) {

--- a/spinnaker/resource_project.go
+++ b/spinnaker/resource_project.go
@@ -1,0 +1,99 @@
+package spinnaker
+
+import (
+	"strings"
+
+	"github.com/armory-io/terraform-provider-spinnaker/spinnaker/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceProject() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+		Create: resourceProjectCreate,
+		Read:   resourceProjectRead,
+		Update: resourceProjectUpdate,
+		Delete: resourceProjectDelete,
+		Exists: resourceProjectExists,
+	}
+}
+
+type projectRead struct {
+	Name       string `json:"name"`
+	Attributes struct {
+		Email string `json:"email"`
+	} `json:"attributes"`
+}
+
+func resourceProjectCreate(data *schema.ResourceData, meta interface{}) error {
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+	project := data.Get("project").(string)
+	email := data.Get("email").(string)
+
+	if err := api.CreateProject(client, project, email); err != nil {
+		return err
+	}
+
+	return resourceProjectRead(data, meta)
+}
+
+func resourceProjectRead(data *schema.ResourceData, meta interface{}) error {
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+	projectName := data.Get("project").(string)
+	var project projectRead
+	if err := api.GetProject(client, projectName, &project); err != nil {
+		return err
+	}
+
+	return readProject(data, project)
+}
+
+func resourceProjectUpdate(data *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceProjectDelete(data *schema.ResourceData, meta interface{}) error {
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+	projectName := data.Get("project").(string)
+
+	return api.DeleteProject(client, projectName)
+}
+
+func resourceProjectExists(data *schema.ResourceData, meta interface{}) (bool, error) {
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+	projectName := data.Get("project").(string)
+
+	var project projectRead
+	if err := api.GetProject(client, projectName, &project); err != nil {
+		errmsg := err.Error()
+		if strings.Contains(errmsg, "not found") {
+			return false, nil
+		} else {
+			return false, err
+		}
+	}
+
+	if project.Name == "" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func readProject(data *schema.ResourceData, project projectRead) error {
+	data.SetId(project.Name)
+	return nil
+}


### PR DESCRIPTION
The `Projects` tab can be helpful to group applications by team-ownership, layer in the stack (frontend, backend, database, etc.), or even by platform type (ec2, kubernetes, etc.). The management of Projects via the UI leaves more to be desired. Adding onto what's already here to see if this can help out! 

- [ ] Address todos 
- [ ] Kick the tires 
  - https://www.terraform.io/docs/extend/writing-custom-providers.html#building-the-plugin