### PR TITLE
Enable authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ See [Terraform documentation](https://www.terraform.io/docs/configuration/provid
 
 ```
 provider "spinnaker" {
-    server = "http://spinnaker-gate.myorg.io"
+    server             = "http://spinnaker-gate.myorg.io"
+    config             = "/path/to/config.yml"
+    ignore_cert_errors = true
 }
 ```
 
 #### Argument Reference
 
 * `server` - The Gate API Url
+* `config` - (Optional) - Path to Gate config file. See the [Spin CLI](https://github.com/spinnaker/spin/blob/master/config/example.yaml) for an example config.
+* `ignore_cert_errors` - (Optional) - Set this to `true` to ignore certificate errors from Gate. Defaults to `false`.
 
 
 ## Resources

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -15,6 +15,18 @@ func Provider() *schema.Provider {
 				Description: "URL for Gate",
 				DefaultFunc: schema.EnvDefaultFunc("GATE_URL", nil),
 			},
+			"config": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Path to Gate config file",
+				Default:     "",
+			},
+			"ignore_cert_errors": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Ignore certificate errors from Gate",
+				Default:     false,
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"spinnaker_application": resourceApplication(),
@@ -31,13 +43,16 @@ type gateConfig struct {
 
 func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	server := data.Get("server").(string)
+	config := data.Get("config").(string)
+	ignore_cert_errors := data.Get("ignore_cert_errors").(bool)
+
 	flags := pflag.NewFlagSet("default", 1)
 	flags.String("gate-endpoint", server, "")
 	flags.Bool("quiet", false, "")
-	flags.Bool("insecure", false, "")
+	flags.Bool("insecure", ignore_cert_errors, "")
 	flags.Bool("no-color", true, "")
 	flags.String("output", "", "")
-	flags.String("config", "", "")
+	flags.String("config", config, "")
 	// flags.Parse()
 	client, err := gate.NewGateClient(flags)
 	if err != nil {


### PR DESCRIPTION
Enable x509 and oauth2 authentication methods. This uses the same [config file](https://github.com/spinnaker/spin/blob/master/config/example.yaml) as the spin CLI. 



Tested with the following config file:
```yml
---
auth:
  enabled: true
  x509:
    certPath: "spinnaker.crt"
    keyPath: "spinnaker.key"
```