### PR TITLE
Added the "pipeline" datasource

### DIFF
--- a/spinnaker/datasource_pipeline.go
+++ b/spinnaker/datasource_pipeline.go
@@ -1,0 +1,27 @@
+package spinnaker
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func datasourcePipeline() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"application": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"pipeline_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+		Read: resourcePipelineRead,
+	}
+}

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -34,6 +34,9 @@ func Provider() *schema.Provider {
 			"spinnaker_pipeline_template":        resourcePipelineTemplate(),
 			"spinnaker_pipeline_template_config": resourcePipelineTemplateConfig(),
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"spinnaker_pipeline": datasourcePipeline(),
+		},
 		ConfigureFunc: providerConfigureFunc,
 	}
 }


### PR DESCRIPTION
This change adds a "pipeline" datasource, which allows querying for the pipeline id of an existing pipeline.  This allows for pipeline composition using the terraform template syntax substituting the discovered pipeline id.  