### PR TITLE
Add instance_port and permissions to the Application resource, allow updating applications.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -240,7 +240,7 @@
   revision = "fa9f258a92500514cc8e9c67020487709df92432"
 
 [[projects]]
-  digest = "1:8ee6b299ec5e027376522696c4a2d236c5d4da19ccc23d8cc31a3530ce9cb26b"
+  digest = "1:55226d01af9764e7eb44603845b02dfac641b15489ab1b8a285cad577daef85f"
   name = "github.com/hashicorp/terraform"
   packages = [
     "config",
@@ -252,6 +252,8 @@
     "helper/hashcode",
     "helper/hilmapstructure",
     "helper/schema",
+    "helper/structure",
+    "helper/validation",
     "httpclient",
     "moduledeps",
     "plugin",
@@ -615,6 +617,7 @@
   input-imports = [
     "github.com/ghodss/yaml",
     "github.com/hashicorp/terraform/helper/schema",
+    "github.com/hashicorp/terraform/helper/validation",
     "github.com/hashicorp/terraform/plugin",
     "github.com/hashicorp/terraform/terraform",
     "github.com/mitchellh/mapstructure",

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -68,6 +68,26 @@ func CreateApplication(client *gate.GatewayClient, applicationName string, appli
 		return fmt.Errorf("Encountered an error saving application, task output was: %v\n", task)
 	}
 
+	// HACK:
+	// When creating an application with group permissions terraform fails to
+	// read the application due to a HTTP 403. It looks like the permissions
+	// are set without refreshing the cache.
+	//
+	// It looks like the responses of the gate API are cached.
+	// Try accessing the application until the cache timeout is reached
+	// and the API allows access to the application.
+	// The default redis cache timeout is 30 seconds.
+	attempts = 0
+	for attempts < 10 {
+		_, resp, _ := client.ApplicationControllerApi.GetApplicationUsingGET(client.Context, applicationName, map[string]interface{}{})
+		if resp != nil && resp.StatusCode != 403 {
+			break
+		}
+
+		attempts += 1
+		time.Sleep(time.Duration(10) * time.Second)
+	}
+
 	return nil
 }
 

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -31,16 +31,10 @@ func GetApplication(client *gate.GatewayClient, applicationName string, dest int
 	return nil
 }
 
-func CreateApplication(client *gate.GatewayClient, applicationName, email string) error {
-
-	app := map[string]interface{}{
-		"instancePort": 80,
-		"name":         applicationName,
-		"email":        email,
-	}
+func CreateApplication(client *gate.GatewayClient, applicationName string, application interface{}) error {
 
 	createAppTask := map[string]interface{}{
-		"job":         []interface{}{map[string]interface{}{"type": "createApplication", "application": app}},
+		"job":         []interface{}{map[string]interface{}{"type": "createApplication", "application": application}},
 		"application": applicationName,
 		"description": fmt.Sprintf("Create Application: %s", applicationName),
 	}

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -16,7 +16,7 @@ func GetApplication(client *gate.GatewayClient, applicationName string, dest int
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Application '%s' not found\n", applicationName)
 		} else if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Encountered an error getting application, status code: %d\n", resp.StatusCode)
+			return fmt.Errorf("Encountered an error getting application: %s status code: %d\n", err, resp.StatusCode)
 		}
 	}
 

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -50,10 +50,9 @@ type applicationRead struct {
 func resourceApplicationCreate(data *schema.ResourceData, meta interface{}) error {
 	clientConfig := meta.(gateConfig)
 	client := clientConfig.client
-	application := data.Get("application").(string)
-	email := data.Get("email").(string)
 
-	if err := api.CreateApplication(client, application, email); err != nil {
+	app := applicationFromResource(data)
+	if err := api.CreateApplication(client, app.Name, app); err != nil {
 		return err
 	}
 

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -27,11 +27,24 @@ func resourceApplication() *schema.Resource {
 	}
 }
 
+// application represents the Gate API schema
+//
+// HINT: to extend this schema have a look at the output
+// of the spin (https://github.com/spinnaker/spin)
+// application get command.
+type application struct {
+	Name         string              `json:"name"`
+	Email        string              `json:"email"`
+	InstancePort int                 `json:"instancePort"`
+	Permissions  map[string][]string `json:"permissions,omitempty"`
+}
+
+// applicationRead represents the Gate API schema of an application
+// get request. The relevenat part of the schema is identical with
+// the application struct, it's just wrapped in an attributes field.
 type applicationRead struct {
-	Name       string `json:"name"`
-	Attributes struct {
-		Email string `json:"email"`
-	} `json:"attributes"`
+	Name       string       `json:"name"`
+	Attributes *application `json:"attributes"`
 }
 
 func resourceApplicationCreate(data *schema.ResourceData, meta interface{}) error {

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -62,9 +62,10 @@ func resourceApplicationCreate(data *schema.ResourceData, meta interface{}) erro
 func resourceApplicationRead(data *schema.ResourceData, meta interface{}) error {
 	clientConfig := meta.(gateConfig)
 	client := clientConfig.client
+
 	applicationName := data.Get("application").(string)
-	var app applicationRead
-	if err := api.GetApplication(client, applicationName, &app); err != nil {
+	app := &applicationRead{}
+	if err := api.GetApplication(client, applicationName, app); err != nil {
 		return err
 	}
 

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -90,7 +90,16 @@ func resourceApplicationRead(data *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceApplicationUpdate(data *schema.ResourceData, meta interface{}) error {
-	return nil
+	// the application update in spinnaker is an simple upsert
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+
+	app := applicationFromResource(data)
+	if err := api.CreateApplication(client, app.Name, app); err != nil {
+		return err
+	}
+
+	return resourceApplicationRead(data, meta)
 }
 
 func resourceApplicationDelete(data *schema.ResourceData, meta interface{}) error {

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -13,10 +13,24 @@ func resourceApplication() *schema.Resource {
 			"application": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"email": {
 				Type:     schema.TypeString,
 				Required: true,
+			},
+			"instance_port": {
+				Type:         schema.TypeInt,
+				Required:     false,
+				Optional:     true,
+				Default:      80,
+			},
+			"permissions": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+				},
 			},
 		},
 		Create: resourceApplicationCreate,

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -152,5 +152,25 @@ func applicationFromResource(data *schema.ResourceData) *application {
 
 func readApplication(data *schema.ResourceData, application *applicationRead) error {
 	data.SetId(application.Name)
+	data.Set("name", application.Name)
+	data.Set("email", application.Attributes.Email)
+	data.Set("instance_port", application.Attributes.InstancePort)
+
+	// convert {"READ": ["team_name"], "WRITE": ["team_name"]} to {"team_name": "read_write"}
+	// for the spinnaker API
+	perms := make(map[string]string)
+	for _, team := range application.Attributes.Permissions["READ"] {
+		perms[team] = "read"
+	}
+	for _, team := range application.Attributes.Permissions["WRITE"] {
+		perm, ok := perms[team]
+		if ok {
+			// perms contains "read", append undescore to create "read_write"
+			perm += "_"
+		}
+		perm += "write"
+		perms[team] = perm
+	}
+	data.Set("permissions", perms)
 	return nil
 }

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/armory-io/terraform-provider-spinnaker/spinnaker/api"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceApplication() *schema.Resource {
@@ -24,12 +25,14 @@ func resourceApplication() *schema.Resource {
 				Required:     false,
 				Optional:     true,
 				Default:      80,
+				ValidateFunc: validation.IntBetween(1, 65535),
 			},
 			"permissions": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"read", "write", "read_write"}, false),
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds instance_port and permissions to the application resource schema.
In addition it implements the the `resourceApplicationUpdate` function to allow terraform to update a spinnaker application. 

This PR includes a dirty hack, which I'm happy to fix if someone knows how. 
When adding permissions to an application, on create, the permissions are not visible to 
the Gate API and terraform receives an HTTP 403 when trying to read the application.
Terraform needs to wait until the cache is refreshed, but it dose not know how long (cache timeout).
I didn't found a way to force a cache invalidation or refresh the cache before reading the application.
