### PR TITLE
spinnaker pipeline document data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ resource "spinnaker_pipeline" "terraform_example" {
 * `name` - Pipeline name
 * `pipeline` - Pipeline JSON in string format, example `file(pipelines/example.json)`
 
+
+## Data source
+
 ### `spinnaker_pipeline_template`
 
 #### Example Usage
@@ -132,3 +135,228 @@ resource "spinnaker_pipeline_template_config" "terraform_example" {
 #### Argument Reference
 
 * `pipeline_config` - A yaml formated [DCD Spec pipeline configuration](https://github.com/spinnaker/dcd-spec/blob/master/PIPELINE_TEMPLATES.md#configurations)
+
+
+### `spinnaker_pipeline_document`
+
+#### Example Usage
+
+```
+data "spinnaker_pipeline_document" "parameters" {
+  parameter {
+    description = "The description of the parameter"
+    default     = "default value"
+    name        = "PARAMETER1"
+    required    = true
+  }
+
+  parameter {
+    name        = "ENVIRONMENT"
+    required    = false
+    options = [
+        "prod",
+        "preprod",
+    ]
+  }
+}
+
+data "spinnaker_pipeline_document" "doc" {
+  description      = "demonstrate pipeline document"
+  wait             = true
+  limit_concurrent = false
+
+  // source parameters
+  source_json = "${data.spinnaker_pipeline_document.parameters.json}"
+
+  parameter {
+      name = "ANOTHER_PARAMETER"
+  }
+
+  // run Job kubernetes v1
+  stage {
+    name                = "stage name"
+    namespace           = "namespace-name"
+    account             = "k8s-account"
+    application         = "${spinnaker_application.my-app.application}"
+    cloud_provider      = "kubernetes"
+    cloud_provider_type = "kubernetes"
+
+    container {
+      name              = "container-name"
+      image_pull_policy = "ALWAYS"
+
+      args = [
+        "argument",
+      ]
+
+      "command" = [
+        "/opt/bin/app.sh",
+      ]
+
+      env {
+        WORKSPACE = "$${parameters["ENVIRONMENT"]}"
+        HOST      = "localhost"
+      }
+
+      image {
+        account    = "gcr"
+        id         = "gcr.io/image:tag"
+        registry   = "gcr.io"
+        repository = "image"
+        tag        = "tag"
+      }
+
+      ports {
+        container = 80
+        name      = "http"
+        protocol  = "TCP"
+      }
+    }
+
+    deferred_initialization = true
+    dns_policy              = "ClusterFirst"
+    id                      = "1"
+    type                    = "runJob"
+    wait_for_completion     = true
+  }
+
+  // manual Judgment
+  stage {
+    name                   = "Manual Judgment"
+    fail_pipeline          = true
+    instructions           = "Apply?"
+    judgment_inputs        = ["yes", "no"]
+    id                     = "2"
+    depends_on             = ["6"]
+
+    stage_enabled {
+      expression = "Spring Expression Language (SpEL) here"
+    }
+
+    type = "manualJudgment"
+  }
+
+  // run Job - kubernetes v1
+  stage {
+    name                = "apply"
+    namespace           = "namespace-name"
+    account             = "k8s-account"
+    application         = "${spinnaker_application.my-app.application}"
+    cloud_provider      = "kubernetes"
+    cloud_provider_type = "kubernetes"
+
+    container {
+      name              = "another name for the container"
+      image_pull_policy = "ALWAYS"
+
+      args = [
+        "apply",
+      ]
+
+      "command" = [
+        "/opt/bin/app.sh",
+      ]
+
+      env {
+        WORKSPACE = "$${parameters["ENVIRONMENT"]}"
+        HOST      = "localhost"  
+      }
+
+      image {
+        account    = "gcr"
+        id         = "gcr.io/image:tag"
+        registry   = "gcr.io"
+        repository = "image"
+        tag        = "tag"
+      }
+    }
+
+    deferred_initialization = true
+    dns_policy              = "ClusterFirst"
+    id                      = "3"
+    type                    = "runJob"
+    depends_on              = ["2"]
+    wait_for_completion     = true
+
+    stage_enabled {
+      expression = "$${ #judgment("Manual Judgment").equals("yes")}"
+    }
+  }
+
+  // wait
+  stage {
+    name                   = "exit"
+    id                     = "4"
+    depends_on             = ["2"]
+
+    stage_enabled {
+      expression = "$${ #judgment("Manual Judgment").equals("no")}"
+    }
+
+    type      = "wait"
+    wait_time = 1
+  }
+
+  // evaluate Variables
+  stage {
+    name                      = "Evaluate variables"
+    fail_on_failed_expression = true
+    id                        = 5
+    depends_on                = ["3"]
+    type                      = "evaluateVariables"
+
+    variables {
+      VARIABLE_NAME = "SpEL here"
+    }
+  }
+
+  // preconditions
+  stage {
+    name                   = "Changes to apply"
+    id                     = 6
+    depends_on             = ["1"]
+    type                   = "checkPreconditions"
+
+    precondition {
+      context {
+        expression = "SpEL here"
+      }
+
+      fail_pipeline = false
+      type          = "expression"
+    }
+  }
+
+  // preconditions 
+  stage {
+    name                   = "No changes to apply"
+    id                     = 7
+    depends_on             = ["1"]
+    type                   = "checkPreconditions"
+
+    precondition {
+      context {
+        expression = "SpEL here"
+      }
+
+      fail_pipeline = false
+      type          = "expression"
+    }
+  }
+
+  // evaluate variables
+
+}
+
+resource "spinnaker_pipeline" "example" {
+  application = "${spinnaker_application.my-app.application}"
+  name        = "example"
+  pipeline    = "${data.spinnaker_pipeline_document.doc.json}"
+}
+```
+
+#### Argument Reference
+
+* `parameter` - Pipeline's parameter; can repeat multiple times  
+* `source_json` - A json formatted string with the predefined parameters
+* `stage` - Pipeline stage; can repeat multiple times

--- a/spinnaker/api/helper.go
+++ b/spinnaker/api/helper.go
@@ -1,0 +1,54 @@
+package api
+
+// Merge takes two PipelineDocuments and merge them
+func (oldDoc *PipelineDocument) Merge(newDoc *PipelineDocument) {
+	// Update some fields of oldDoc to match newDoc now
+	if newDoc.AppConfig != nil {
+		oldDoc.AppConfig = newDoc.AppConfig
+	}
+	if newDoc.Description != "" {
+		oldDoc.Description = newDoc.Description
+	}
+	if newDoc.ExecutionEngine != "" {
+		oldDoc.ExecutionEngine = newDoc.ExecutionEngine
+	}
+	if newDoc.Parallel != nil {
+		oldDoc.Parallel = newDoc.Parallel
+	}
+	if newDoc.LimitConcurrent != nil {
+		oldDoc.LimitConcurrent = newDoc.LimitConcurrent
+	}
+	if newDoc.KeepWaitingPipelines != nil {
+		oldDoc.KeepWaitingPipelines = newDoc.KeepWaitingPipelines
+	}
+	if newDoc.Parameters != nil {
+		for _, newParam := range newDoc.Parameters {
+			found := false
+			for idx, oldParam := range oldDoc.Parameters {
+				if oldParam.Name == newParam.Name {
+					oldDoc.Parameters[idx] = newParam
+					found = true
+					continue
+				}
+			}
+			if !found {
+				oldDoc.Parameters = append(oldDoc.Parameters, newParam)
+			}
+		}
+	}
+	if newDoc.Stages != nil {
+		for _, newStage := range newDoc.Stages {
+			found := false
+			for idx, oldStage := range oldDoc.Stages {
+				if oldStage.Name == newStage.Name {
+					oldDoc.Stages[idx] = newStage
+					found = true
+					continue
+				}
+			}
+			if !found {
+				oldDoc.Stages = append(oldDoc.Stages, newStage)
+			}
+		}
+	}
+}

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -28,13 +28,17 @@ type PipelineDocument struct {
 }
 
 type PipelineParameter struct {
-	Description string   `json:"description,omitempty"`
-	Default     string   `json:"default,omitempty"`
-	Name        string   `json:"name"`
-	Required    bool     `json:"required"`
-	HasOptions  bool     `json:"hasOptions"`
-	Label       string   `json:"label,omitempty"`
-	Options     []string `json:"options,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Default     string     `json:"default"`
+	Name        string     `json:"name"`
+	Required    bool       `json:"required"`
+	HasOptions  bool       `json:"hasOptions"`
+	Label       string     `json:"label,omitempty"`
+	Options     []*Options `json:"options,omitempty"`
+}
+
+type Options struct {
+	Value string `json:"value"`
 }
 
 type Pipeline struct {
@@ -45,78 +49,6 @@ type Pipeline struct {
 	KeepWaitingPipelines *bool                `json:"keepWaitingPipelines,omitempty" mapstructure:"wait"`
 	Stages               []*Stage             `json:"stages,omitempty" mapstructure:"stage"`
 	Parameters           []*PipelineParameter `json:"parameterConfig,omitempty" mapstructure:"parameter"`
-}
-
-type Stage struct {
-	Account                       string            `json:"account,omitempty"`
-	Application                   string            `json:"application,omitempty"`
-	CloudProvider                 string            `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
-	CloudProviderType             string            `json:"cloudProviderType,omitempty" mapstructure:"cloud_provider_type"`
-	Annotations                   map[string]string `json:"annotations,omitempty"`
-	Clusters                      string            `json:"clusters,omitempty"`
-	CompleteOtherBranchesThenFail bool              `json:"completeOtherBranchesThenFail,omitempty" mapstructure:"complete_other_branches_then_fail"`
-	ContinuePipeline              bool              `json:"continuePipeline,omitempty" mapstructure:"continue_pipeline"`
-	FailPipeline                  bool              `json:"failPipeline,omitempty" mapstructure:"fail_pipeline"`
-	FailOnFailedExpressions       bool              `json:"failOnFailedExpressions,omitempty" mapstructure:"fail_on_failed_expression"`
-	Instructions                  string            `json:"instructions,omitempty"`
-	JudgmentInputs                []struct {
-		Value string `json:"value"`
-	} `json:"judgmentInputs,omitempty"`
-	StageEnabled struct {
-		Expression string `json:"expression,omitempty"`
-		Type       string `json:"type,omitempty"`
-	} `json:"stageEnabled,omitempty"`
-	Pipeline           string            `json:"pipeline,omitempty"`
-	PipelineParameters map[string]string `json:"pipelineParameters,omitempty" mapstructure:"pipeline_parameters"`
-	Variables          []struct {
-		Key   string `json:"key"`
-		Value string `json:"value"`
-	} `json:"variables,omitempty" mapstructure:"-"`
-	Containers []struct {
-		Args    []string `json:"args,omitempty"`
-		Command []string `json:"command,omitempty"`
-		EnvVars []struct {
-			Name  string `json:"name"`
-			Value string `json:"value"`
-		} `json:"envVars,omitempty"`
-		ImageDescription struct {
-			Account    string `json:"account,omitempty"`
-			ImageID    string `json:"imageId,omitempty" mapstructure:"id"`
-			Registry   string `json:"registry,omitempty"`
-			Repository string `json:"repository,omitempty"`
-			Tag        string `json:"tag,omitempty"`
-		} `json:"imageDescription,omitempty" mapstructure:"image"`
-		ImagePullPolicy string `json:"imagePullPolicy,omitempty" mapstructure:"image_pull_policy"`
-		Name            string `json:"name,omitempty"`
-		Ports           []struct {
-			ContainerPort int    `json:"containerPort,omitempty" mapstructure:"container"`
-			Name          string `json:"name,omitempty"`
-			Protocol      string `json:"protocol,omitempty"`
-		} `json:"ports,omitempty"`
-	} `json:"containers,omitempty" mapstructure:"container"`
-	Preconditions []struct {
-		CloudProvider string `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
-		Context       struct {
-			Cluster     string   `json:"cluster,omitempty"`
-			Comparison  string   `json:"comparison,omitempty"`
-			Credentials string   `json:"credentials,omitempty"`
-			Expected    int      `json:"expected,omitempty"`
-			Regions     []string `json:"regions,omitempty"`
-			Expression  string   `json:"expression,omitempty"`
-		} `json:"context,omitempty"`
-		FailPipeline bool   `json:"failPipeline" mapstructure:"fail_pipeline"`
-		Type         string `json:"type"`
-	} `json:"preconditions,omitempty" mapstructure:"precondition"`
-	DeferredInitialization *bool         `json:"deferredInitialization,omitempty" mapstructure:"deferred_initialization"`
-	DNSPolicy              string        `json:"dnsPolicy,omitempty" mapstructure:"dns_policy"`
-	Name                   string        `json:"name,omitempty"`
-	Namespace              string        `json:"namespace,omitempty"`
-	RefID                  string        `json:"refId,omitempty" mapstructure:"ref_id"`
-	RequisiteStageRefIds   []interface{} `json:"requisiteStageRefIds,omitempty" mapstructure:"requisite_stage_refids"`
-	Type                   string        `json:"type,omitempty"`
-	StatusURLResolution    string        `json:"statusUrlResolution,omitempty" mapstructure:"status_url_resolution"`
-	WaitTime               int           `json:"waitTime,omitempty" mapstructure:"wait_time"`
-	WaitForCompletion      bool          `json:"waitForCompletion,omitempty" mapstructure:"wait_for_completion"`
 }
 
 func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -8,6 +8,117 @@ import (
 	gate "github.com/spinnaker/spin/cmd/gateclient"
 )
 
+type PipelineConfig struct {
+	Pipeline
+	ID                string                   `json:"id,omitempty"`
+	Type              string                   `json:"type,omitempty"`
+	Name              string                   `json:"name"`
+	Application       string                   `json:"application"`
+	Triggers          []map[string]interface{} `json:"triggers,omitempty"`
+	ExpectedArtifacts []map[string]interface{} `json:"expectedArtifacts,omitempty"`
+	Notifications     []map[string]interface{} `json:"notifications,omitempty"`
+	LastModifiedBy    string                   `json:"lastModifiedBy"`
+	Config            interface{}              `json:"config,omitempty"`
+	UpdateTs          string                   `json:"updateTs,omitempty"`
+}
+
+type PipelineDocument struct {
+	Pipeline
+	AppConfig map[string]string `json:"appConfig,omitempty" mapstructure:"config"`
+}
+
+type PipelineParameter struct {
+	Description string   `json:"description,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Name        string   `json:"name"`
+	Required    bool     `json:"required"`
+	HasOptions  bool     `json:"hasOptions"`
+	Label       string   `json:"label,omitempty"`
+	Options     []string `json:"options,omitempty"`
+}
+
+type Pipeline struct {
+	Description          string               `json:"description,omitempty"`
+	ExecutionEngine      string               `json:"executionEngine,omitempty" mapstructure:"engine"`
+	Parallel             *bool                `json:"parallel,omitempty"`
+	LimitConcurrent      *bool                `json:"limitConcurrent,omitempty" mapstructure:"limit_concurrent"`
+	KeepWaitingPipelines *bool                `json:"keepWaitingPipelines,omitempty" mapstructure:"wait"`
+	Stages               []*Stage             `json:"stages,omitempty" mapstructure:"stage"`
+	Parameters           []*PipelineParameter `json:"parameterConfig,omitempty" mapstructure:"parameter"`
+}
+
+type Stage struct {
+	Account                       string            `json:"account,omitempty"`
+	Application                   string            `json:"application,omitempty"`
+	CloudProvider                 string            `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
+	CloudProviderType             string            `json:"cloudProviderType,omitempty" mapstructure:"cloud_provider_type"`
+	Annotations                   map[string]string `json:"annotations,omitempty"`
+	Clusters                      string            `json:"clusters,omitempty"`
+	CompleteOtherBranchesThenFail bool              `json:"completeOtherBranchesThenFail,omitempty" mapstructure:"complete_other_branches_then_fail"`
+	ContinuePipeline              bool              `json:"continuePipeline,omitempty" mapstructure:"continue_pipeline"`
+	FailPipeline                  bool              `json:"failPipeline,omitempty" mapstructure:"fail_pipeline"`
+	FailOnFailedExpressions       bool              `json:"failOnFailedExpressions,omitempty" mapstructure:"fail_on_failed_expression"`
+	Instructions                  string            `json:"instructions,omitempty"`
+	JudgmentInputs                []struct {
+		Value string `json:"value"`
+	} `json:"judgmentInputs,omitempty"`
+	StageEnabled struct {
+		Expression string `json:"expression,omitempty"`
+		Type       string `json:"type,omitempty"`
+	} `json:"stageEnabled,omitempty"`
+	Pipeline           string            `json:"pipeline,omitempty"`
+	PipelineParameters map[string]string `json:"pipelineParameters,omitempty" mapstructure:"pipeline_parameters"`
+	Variables          []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"variables,omitempty" mapstructure:"-"`
+	Containers []struct {
+		Args    []string `json:"args,omitempty"`
+		Command []string `json:"command,omitempty"`
+		EnvVars []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"envVars,omitempty"`
+		ImageDescription struct {
+			Account    string `json:"account,omitempty"`
+			ImageID    string `json:"imageId,omitempty" mapstructure:"id"`
+			Registry   string `json:"registry,omitempty"`
+			Repository string `json:"repository,omitempty"`
+			Tag        string `json:"tag,omitempty"`
+		} `json:"imageDescription,omitempty" mapstructure:"image"`
+		ImagePullPolicy string `json:"imagePullPolicy,omitempty" mapstructure:"image_pull_policy"`
+		Name            string `json:"name,omitempty"`
+		Ports           []struct {
+			ContainerPort int    `json:"containerPort,omitempty" mapstructure:"container"`
+			Name          string `json:"name,omitempty"`
+			Protocol      string `json:"protocol,omitempty"`
+		} `json:"ports,omitempty"`
+	} `json:"containers,omitempty" mapstructure:"container"`
+	Preconditions []struct {
+		CloudProvider string `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
+		Context       struct {
+			Cluster     string   `json:"cluster,omitempty"`
+			Comparison  string   `json:"comparison,omitempty"`
+			Credentials string   `json:"credentials,omitempty"`
+			Expected    int      `json:"expected,omitempty"`
+			Regions     []string `json:"regions,omitempty"`
+			Expression  string   `json:"expression,omitempty"`
+		} `json:"context,omitempty"`
+		FailPipeline bool   `json:"failPipeline" mapstructure:"fail_pipeline"`
+		Type         string `json:"type"`
+	} `json:"preconditions,omitempty" mapstructure:"precondition"`
+	DeferredInitialization *bool         `json:"deferredInitialization,omitempty" mapstructure:"deferred_initialization"`
+	DNSPolicy              string        `json:"dnsPolicy,omitempty" mapstructure:"dns_policy"`
+	Name                   string        `json:"name,omitempty"`
+	Namespace              string        `json:"namespace,omitempty"`
+	RefID                  string        `json:"refId,omitempty" mapstructure:"ref_id"`
+	RequisiteStageRefIds   []interface{} `json:"requisiteStageRefIds,omitempty" mapstructure:"requisite_stage_refids"`
+	Type                   string        `json:"type,omitempty"`
+	StatusURLResolution    string        `json:"statusUrlResolution,omitempty" mapstructure:"status_url_resolution"`
+	WaitTime               int           `json:"waitTime,omitempty" mapstructure:"wait_time"`
+	WaitForCompletion      bool          `json:"waitForCompletion,omitempty" mapstructure:"wait_for_completion"`
+}
+
 func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
 	resp, err := client.PipelineControllerApi.SavePipelineUsingPOST(client.Context, pipeline)
 

--- a/spinnaker/api/stage.go
+++ b/spinnaker/api/stage.go
@@ -1,0 +1,167 @@
+package api
+
+type ManualJudgment struct {
+	JudgmentInputs []struct {
+		Value string `json:"value"`
+	} `json:"judgmentInputs,omitempty"`
+	Instructions string `json:"instructions,omitempty"`
+}
+
+type Notification struct {
+	Address string `json:"address,omitempty"`
+	Cc      string `json:"cc,omitempty"`
+	Level   string `json:"level,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Message struct {
+		StageCompleted struct {
+			Text string `json:",omitempty"`
+		} `json:"stage.completed,omitempty"`
+		StageFailed struct {
+			Text string `json:",omitempty"`
+		} `json:"stage.failed,omitempty"`
+		StageStarting struct {
+			Text string `json:",omitempty"`
+		} `json:"stage.starting,omitempty"`
+	} `json:"message,omitempty"`
+	When []string `json:"when,omitempty"`
+}
+
+type RunJob struct {
+	Kubernetes `mapstructure:",squash"`
+}
+
+type Kubernetes struct {
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+
+	Containers []struct {
+		Args    []string `json:"args,omitempty"`
+		Command []string `json:"command,omitempty"`
+		EnvVars []struct {
+			Name  string `json:"name"`
+			Value string `json:"value"`
+		} `json:"envVars,omitempty"`
+		ImageDescription struct {
+			Account    string `json:"account,omitempty"`
+			ImageID    string `json:"imageId,omitempty" mapstructure:"id"`
+			Registry   string `json:"registry,omitempty"`
+			Repository string `json:"repository,omitempty"`
+			Tag        string `json:"tag,omitempty"`
+		} `json:"imageDescription,omitempty" mapstructure:"image"`
+		ImagePullPolicy string `json:"imagePullPolicy,omitempty" mapstructure:"image_pull_policy"`
+		Name            string `json:"name,omitempty"`
+		Ports           []struct {
+			ContainerPort int    `json:"containerPort,omitempty" mapstructure:"container"`
+			HostPort      int    `json:"hostPort,omitempty" mapstructure:"host"`
+			HostIP        string `json:"hostIp,omitempty" mapstructure:"hostip"`
+			Name          string `json:"name,omitempty"`
+			Protocol      string `json:"protocol,omitempty"`
+		} `json:"ports,omitempty"`
+		Limits struct {
+			CPU    string
+			Memory string
+		} `json:"limits,omitempty"`
+		Volumes []struct {
+			MountPath string `json:"mountPath,omitempty" mapstructure:"mount_path"`
+			Name      string `json:"name,omitempty"`
+			ReadOnly  bool   `json:"readOnly,omitempty" mapstructure:"read_only"`
+			SubPath   string `json:"subPath,omitempty" mapstructure:"sub_path"`
+		} `json:"volumeMounts,omitempty"`
+	} `json:"containers,omitempty" mapstructure:"container"`
+
+	NodeSelector       map[string]string `json:"nodeSelector,omitempty" mapstructure:"node_selector"`
+	ServiceAccountName string            `json:"serviceAccountName,omitempty" mapstructure:"service_account_name"`
+	DNSPolicy          string            `json:"dnsPolicy,omitempty" mapstructure:"dns_policy"`
+	Labels             map[string]string `json:"labels,omitempty"`
+}
+
+type CheckPrecondition struct {
+	Preconditions []struct {
+		CloudProvider string `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
+		Context       struct {
+			Cluster     string   `json:"cluster,omitempty"`
+			Comparison  string   `json:"comparison,omitempty"`
+			Credentials string   `json:"credentials,omitempty"`
+			Expected    int      `json:"expected,omitempty"`
+			Regions     []string `json:"regions,omitempty"`
+			Expression  string   `json:"expression,omitempty"`
+		} `json:"context,omitempty"`
+		FailPipeline bool   `json:"failPipeline" mapstructure:"fail_pipeline"`
+		Type         string `json:"type"`
+	} `json:"preconditions,omitempty" mapstructure:"precondition"`
+}
+
+type RunPipeline struct {
+	Application        string            `json:"application,omitempty"`
+	Pipeline           string            `json:"pipeline,omitempty"`
+	PipelineParameters map[string]string `json:"pipelineParameters,omitempty" mapstructure:"pipeline_parameters"`
+}
+
+type EvaluateVariables struct {
+	Variables []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"variables,omitempty" mapstructure:"-"`
+}
+
+type Wait struct {
+	SkipText string `json:"skipWaitText,omitempty" mapstructure:"skip_text"`
+	WaitTime int    `json:"waitTime,omitempty" mapstructure:"wait_time"`
+}
+
+type DeployManifest struct {
+	ManifestArtifactAccount  string                   `json:"manifestArtifactAccount,omitempty" mapstructure:"manifest_artifact_account"`
+	Moniker                  map[string]string        `json:"moniker,omitempty"`
+	SkipExpressionEvaluation bool                     `json:"skipExpressionEvaluation,omitempty" mapstructure:"skip_expression_evaluation"`
+	Manifests                []map[string]interface{} `json:"manifests,omitempty" mapstructure:"-"`
+}
+
+type RunJobManifest struct {
+	Alias                 string                 `json:"alias,omitempty" mapstructure:"-"`
+	ConsumeArtifactSource string                 `json:"consumeArtifactSource,omitempty" mapstructure:"consume_artifact_source"`
+	PropertyFile          string                 `json:"propertyFile,omitempty" mapstructure:"property_file"`
+	Manifest              map[string]interface{} `json:"manifest,omitempty" mapstructure:"-"`
+}
+
+type KubernetesManifest struct {
+	Source string `json:"source,omitempty"`
+
+	RunJobManifest `mapstructure:",squash"`
+	DeployManifest `mapstructure:",squash"`
+}
+
+type Stage struct {
+	// shared properties among all the stage types
+	Account                       string `json:"account,omitempty"`
+	CloudProvider                 string `json:"cloudProvider,omitempty" mapstructure:"cloud_provider"`
+	CloudProviderType             string `json:"cloudProviderType,omitempty" mapstructure:"cloud_provider_type"`
+	CompleteOtherBranchesThenFail *bool  `json:"completeOtherBranchesThenFail,omitempty" mapstructure:"complete_other_branches_then_fail"`
+	ContinuePipeline              *bool  `json:"continuePipeline,omitempty" mapstructure:"continue_pipeline"`
+	FailPipeline                  *bool  `json:"failPipeline,omitempty" mapstructure:"fail_pipeline"`
+	FailOnFailedExpressions       *bool  `json:"failOnFailedExpressions,omitempty" mapstructure:"fail_on_failed_expression"`
+	StageEnabled                  struct {
+		Expression string `json:"expression,omitempty"`
+		Type       string `json:"type,omitempty"`
+	} `json:"stageEnabled,omitempty"`
+
+	DeferredInitialization bool     `json:"deferredInitialization,omitempty" mapstructure:"deferred_initialization"`
+	Name                   string   `json:"name,omitempty"`
+	RefID                  string   `json:"refId,omitempty" mapstructure:"id"`
+	RequisiteStageRefIds   []string `json:"requisiteStageRefIds,omitempty" mapstructure:"depends_on"`
+	Type                   string   `json:"type,omitempty"`
+	WaitForCompletion      bool     `json:"waitForCompletion,omitempty" mapstructure:"wait_for_completion"`
+
+	// Notifications and SendNotifcations is shared between:
+	// runPipeline and manualJudgment
+	Notifications    []*Notification `json:"notification,omitempty" mapstructure:"notification"`
+	SendNotification bool            `json:"sendNotifications"`
+
+	// embedded structs/stage types
+	ManualJudgment     `json:",omitempty" mapstructure:",squash"`
+	RunJob             `json:",omitempty" mapstructure:",squash"`
+	CheckPrecondition  `json:",omitempty" mapstructure:",squash"`
+	RunPipeline        `json:",omitempty" mapstructure:",squash"`
+	EvaluateVariables  `json:",omitempty" mapstructure:",squash"`
+	Wait               `json:",omitempty" mapstructure:",squash"`
+	KubernetesManifest `json:",omitempty" mapstructure:",squash"`
+}

--- a/spinnaker/datasource_pipeline.go
+++ b/spinnaker/datasource_pipeline.go
@@ -9,12 +9,10 @@ func datasourcePipeline() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"application": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Required: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
-				ForceNew: true,
 				Required: true,
 			},
 			"pipeline": {

--- a/spinnaker/datasource_pipeline_document.go
+++ b/spinnaker/datasource_pipeline_document.go
@@ -1,0 +1,556 @@
+package spinnaker
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+
+	"github.com/armory-io/terraform-provider-spinnaker/spinnaker/api"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/mitchellh/mapstructure"
+)
+
+func datasourcePipelineDocument() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourcePipelineDocumentRead,
+		Schema: map[string]*schema.Schema{
+			"json": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"override_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"parallel": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"limit_concurrent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"wait": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"parameter": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"default": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"required": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"label": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"options": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
+			"stage": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"account": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"cloud_provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"cloud_provider_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"annotations": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+						"clusters": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"complete_other_branches_then_fail": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"continue_pipeline": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"fail_pipeline": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"fail_on_failed_expression": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"pipeline": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"pipeline_parameters": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+						"application": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"variables": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+						"precondition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"cloud_provider": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"fail_pipeline": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"context": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"cluster": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"comparison": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"credentials": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"expected": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"regions": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeString,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"container": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"args": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"command": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Schema{
+											Type: schema.TypeString,
+										},
+									},
+									"env": {
+										Type:     schema.TypeMap,
+										Optional: true,
+									},
+									"image": {
+										Type:     schema.TypeMap,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"account": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"id": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"registry": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"repository": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"tag": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Default:  "latest",
+												},
+											},
+										},
+									},
+									"image_pull_policy": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"ports": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"container": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"name": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+												"protocol": {
+													Type:     schema.TypeString,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"deferred_initialization": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"dns_policy": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"namespace": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ref_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"wait_for_completion": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"instructions": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"judgment_inputs": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"requisite_stage_refids": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"wait_time": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"status_url_resolution": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"stage_enabled": {
+							Type:     schema.TypeMap,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourcePipelineDocumentRead(d *schema.ResourceData, meta interface{}) error {
+	spDoc := &api.PipelineDocument{}
+
+	mergeDoc := &api.PipelineDocument{}
+	if sourceJSON, hasSourceJSON := d.GetOk("source_json"); hasSourceJSON {
+		if err := json.Unmarshal([]byte(sourceJSON.(string)), mergeDoc); err != nil {
+			return err
+		}
+	}
+
+	if appConfig, ok := d.GetOk("config"); ok {
+		spDoc.AppConfig = appConfig.(map[string]string)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		spDoc.Description = description.(string)
+	}
+
+	if executionEngine, ok := d.GetOk("engine"); ok {
+		spDoc.ExecutionEngine = executionEngine.(string)
+	}
+
+	if parallel, ok := d.GetOkExists("parallel"); ok {
+		spDoc.Parallel = Bool(parallel.(bool))
+	}
+	if limitConcurrent, ok := d.GetOkExists("limit_concurrent"); ok {
+		spDoc.LimitConcurrent = Bool(limitConcurrent.(bool))
+	}
+	if keepWaiting, ok := d.GetOkExists("wait"); ok {
+		spDoc.KeepWaitingPipelines = Bool(keepWaiting.(bool))
+	}
+
+	// decouple parameters
+	if parameters, ok := d.GetOk("parameter"); ok {
+		spDoc.Parameters = parametersDecodeDocument(parameters)
+	}
+
+	// decouple stages
+	if stages, ok := d.GetOk("stage"); ok {
+		stgs, err := stageDecodeDocument(stages)
+		if err != nil {
+			return err
+		}
+		spDoc.Stages = stgs
+	}
+
+	if overrideJSON, hasOverrideJSON := d.GetOk("override_json"); hasOverrideJSON {
+		overrideDoc := &api.PipelineDocument{}
+		if err := json.Unmarshal([]byte(overrideJSON.(string)), overrideDoc); err != nil {
+			return err
+		}
+		mergeDoc.Merge(overrideDoc)
+	}
+
+	// Perform overrides. If no overrides/source provided it will do nothing.
+	mergeDoc.Merge(spDoc)
+	render, err := json.Marshal(&mergeDoc)
+	if err != nil {
+		return err
+	}
+
+	jsonDocument := string(render)
+	d.SetId(strconv.Itoa(hashcode.String(jsonDocument)))
+	d.Set("json", jsonDocument)
+
+	return nil
+}
+
+// parametersDecodeDocument iterates over each parameter. The schema for the parameters
+// is being set to TypeSet, which means in that case order does not matter.
+// The parameter "hasOptions" is assumed based on the fact if the "options" are being
+// populated or not
+func parametersDecodeDocument(parameters interface{}) []*api.PipelineParameter {
+	var selParams = parameters.(*schema.Set).List()
+	params := make([]*api.PipelineParameter, len(selParams))
+
+	for i, param := range selParams {
+		fparam := param.(map[string]interface{})
+		pm := &api.PipelineParameter{
+			Description: fparam["description"].(string),
+			Default:     fparam["default"].(string),
+			Name:        fparam["name"].(string),
+			Required:    fparam["required"].(bool),
+			Label:       fparam["label"].(string),
+		}
+
+		if opts := fparam["options"].([]interface{}); len(opts) > 0 {
+			pm.HasOptions = true
+			for _, opt := range opts {
+				pm.Options = append(pm.Options, opt.(string))
+			}
+		}
+		params[i] = pm
+	}
+	return params
+}
+
+// stageDecodeDocument iterate over the stages in defined order and map
+// all the fields into expected pipeline's json format.
+func stageDecodeDocument(field interface{}) ([]*api.Stage, error) {
+	var stages = field.([]interface{})
+	stgs := make([]*api.Stage, len(stages))
+
+	for i, stg := range stages {
+		stageField := stg.(map[string]interface{})
+		sg := &api.Stage{}
+
+		err := mapstructure.Decode(stageField, &sg)
+		if err != nil {
+			return nil, err
+		}
+
+		// extract env variables if any
+		extractEnvs(stageField["container"].([]interface{}), sg)
+
+		// extract variables
+		if vars, ok := stageField["variables"]; ok {
+			for key, value := range vars.(map[string]interface{}) {
+				sg.Variables = append(sg.Variables, struct {
+					Key   string `json:"key"`
+					Value string `json:"value"`
+				}{
+					Key:   key,
+					Value: value.(string),
+				})
+			}
+		}
+
+		// evaluate if judgment manual is set, map string values to map
+		if judgmentInputs, ok := stageField["judgment_inputs"]; ok {
+			for _, inpt := range judgmentInputs.([]interface{}) {
+				sg.JudgmentInputs = append(sg.JudgmentInputs, struct {
+					Value string `json:"value"`
+				}{
+					Value: inpt.(string),
+				})
+			}
+		}
+
+		// stage_enabled is being populated in pipeline's json only if
+		// the Execution Optional within the job definition is set to "Conditional on Expression"
+		// The only accepted type in spinnaker at this moment is "expression"
+		// Instead of accepting:
+		// {
+		//	 expression: "<VALUE>",
+		//   type: "expression"
+		// }
+		// accept:
+		//   expression: "VALUE"
+		// and assume the type
+		if stageEnabled, ok := stageField["stage_enabled"]; ok {
+			// most likely will be iterated only once
+			for key, value := range stageEnabled.(map[string]interface{}) {
+				sg.StageEnabled.Expression = value.(string)
+				sg.StageEnabled.Type = key
+			}
+		}
+
+		stgs[i] = sg
+	}
+	return stgs, nil
+}
+
+// extractEnvs transforms document env variables into pipeline's json
+// Since spinnaker internally sorts all the slices,
+// we need to do the same before passing to pipelineDiffSuppressFunc,
+// otherwise two jsons will always diff.
+//
+// Spinnaker expect envVars to be  in a format:
+// {
+//    Name: "name",
+//    Value: "value"
+// }
+// Although for the simplicity we accept it in the form of:
+// name=value, which makes data source document more readable and short.
+func extractEnvs(fields []interface{}, sg *api.Stage) {
+	for i, elem := range fields {
+		if env, ok := elem.(map[string]interface{})["env"]; ok {
+			var envKeys []string
+			envs := env.(map[string]interface{})
+
+			for k := range envs {
+				envKeys = append(envKeys, k)
+			}
+			sort.Strings(envKeys)
+
+			for _, k := range envKeys {
+				sg.Containers[i].EnvVars = append(sg.Containers[i].EnvVars, struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				}{
+					Name:  k,
+					Value: envs[k].(string),
+				})
+			}
+		}
+	}
+}
+
+// Bool (helper func) returns a bool value from the pointer to bool
+// primary reason for using that is to set some json variables
+// only if the bool has been explicity set.
+// the tag `omitempty` will be only applied if *bool == nil
+func Bool(v bool) *bool {
+	return &v
+}

--- a/spinnaker/datasource_pipeline_document_test.go
+++ b/spinnaker/datasource_pipeline_document_test.go
@@ -1,0 +1,165 @@
+package spinnaker
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/armory-io/terraform-provider-spinnaker/spinnaker/api"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+var tfToGo = map[string]string{
+	"TypeBool":   "bool",
+	"TypeInt":    "int",
+	"TypeFloat":  "float64",
+	"TypeString": "string",
+	"TypeList":   "slice",
+	"TypeMap":    "map",
+	"TypeSet":    "slice",
+}
+
+func TestDocumentSchemaMatchesStruct(t *testing.T) {
+	schemas := make(map[string]string)
+	GetFieldsFromSchema(".pipeline", datasourcePipelineDocument(), schemas)
+
+	tags := make(map[string]string)
+	GetFieldTagsFromStruct("", api.PipelineDocument{}, "mapstructure", tags)
+
+	// some of the fields have different format. The reason for that is to simplify
+	// terraform definition of the reasurce. Because of that schema.Resource does not match
+	// 1:1 the json format. There is a transformation performed in:
+	// parametersDecodeDocument() and stageDecodeDocument(). Other fields are just computed
+	// and not present in the either struct or Schema
+	skipFields := []string{
+		".pipeline", ".pipeline.json", ".pipeline.parameter.hasoptions", ".pipeline.stage.container.env",
+		".pipeline.stage.judgment_inputs", ".pipeline.stage.container.image", ".pipeline.stage.stage_enabled",
+		".pipeline.stage.variables", ".pipeline.stage.container.envvars", "pipeline.stage.container.envvars.name",
+		".pipeline.stage.container.envvars.value", ".pipeline.stage.container.image", ".pipeline.stage.judgmentinputs",
+		".pipeline.stage.judgmentinputs.value", ".pipeline.stage.stageenabled", ".pipeline.stage.stageenabled.expression",
+		".pipeline.stage.stageenabled.type", ".pipeline.stage.variables", ".pipeline.stage.variables.key",
+		".pipeline.stage.variables.value", ".pipeline.source_json", ".pipeline.override_json", ".pipeline.stage.container.envvars.name",
+		".pipeline.limit_concurrent", ".pipeline.parallel", ".pipeline.stage.deferred_initialization", ".pipeline.wait",
+		".pipeline.stage.precondition.context",
+	}
+
+	// transofrm some of the fields to make comparision more accurate.
+	schemas[".config"] = schemas[".pipeline.config"]
+	delete(schemas, ".pipeline.config")
+
+	// some of the fields have different type. In struct representation
+	// they will have more likely `struct` type, in schema either map or slice,
+	// more rare bool ==> ptr mapping
+	assertEqual(t, schemas[".pipeline.stage.container.env"], "map")
+	assertEqual(t, schemas[".pipeline.stage.judgment_inputs"], "slice")
+	assertEqual(t, schemas[".pipeline.stage.container.image"], "map")
+	assertEqual(t, schemas[".pipeline.stage.stage_enabled"], "map")
+	assertEqual(t, schemas[".pipeline.stage.variables"], "map")
+	assertEqual(t, schemas[".pipeline.limit_concurrent"], "bool")
+	assertEqual(t, schemas[".pipeline.parallel"], "bool")
+	assertEqual(t, schemas[".pipeline.stage.deferred_initialization"], "bool")
+	assertEqual(t, schemas[".pipeline.wait"], "bool")
+	assertEqual(t, schemas[".pipeline.stage.precondition.context"], "map")
+
+	assertEqual(t, tags[".pipeline.stage.container.envvars"], "slice")
+	assertEqual(t, tags[".pipeline.stage.container.envvars.name"], "string")
+	assertEqual(t, tags[".pipeline.stage.container.envvars.value"], "string")
+	assertEqual(t, tags[".pipeline.stage.container.image"], "struct")
+	assertEqual(t, tags[".pipeline.stage.judgmentinputs"], "slice")
+	assertEqual(t, tags[".pipeline.stage.judgmentinputs.value"], "string")
+	assertEqual(t, tags[".pipeline.stage.stageenabled"], "struct")
+	assertEqual(t, tags[".pipeline.stage.stageenabled.expression"], "string")
+	assertEqual(t, tags[".pipeline.stage.stageenabled.type"], "string")
+	assertEqual(t, tags[".pipeline.stage.variables"], "slice")
+	assertEqual(t, tags[".pipeline.stage.variables.key"], "string")
+	assertEqual(t, tags[".pipeline.stage.variables.value"], "string")
+	assertEqual(t, tags[".pipeline.limit_concurrent"], "ptr")
+	assertEqual(t, tags[".pipeline.parallel"], "ptr")
+	assertEqual(t, tags[".pipeline.stage.deferred_initialization"], "ptr")
+	assertEqual(t, tags[".pipeline.wait"], "ptr")
+	assertEqual(t, tags[".pipeline.stage.precondition.context"], "struct")
+	// cleanup different values and make assertion
+	for _, skip := range skipFields {
+		delete(schemas, skip)
+		delete(tags, skip)
+	}
+
+	// Final assertion
+	if !reflect.DeepEqual(tags, schemas) {
+		t.Fatal("PipelineDocument struct and data_source_spinnaker_pipeline_document do not match!")
+	}
+}
+
+func GetFieldsFromSchema(prefix string, resource *schema.Resource, schemas map[string]string) {
+	for name, value := range resource.Schema {
+		key := fmt.Sprintf("%s.%s", prefix, name)
+
+		switch value.Type {
+		case schema.TypeList, schema.TypeSet, schema.TypeMap:
+			if elem, ok := value.Elem.(*schema.Resource); ok {
+				schemas[key] = tfToGo[value.Type.String()]
+				GetFieldsFromSchema(key, elem, schemas)
+			} else {
+				schemas[key] = tfToGo[value.Type.String()]
+			}
+		default:
+			schemas[key] = tfToGo[value.Type.String()]
+		}
+	}
+}
+
+// mapTags extracts given tag from the given structure strct
+// and build a map
+func GetFieldTagsFromStruct(prefix string, source interface{}, tagName string, tags map[string]string) {
+	sourceType := reflect.TypeOf(source)
+	sourceValue := reflect.ValueOf(source)
+
+	if sourceValue.Type().Kind() == reflect.Struct {
+		for i := 0; i < sourceType.NumField(); i++ {
+			field := sourceType.Field(i)
+
+			var key string
+			if tag := field.Tag.Get(tagName); tag != "" {
+				// Some values are skipped by mapstructure since they have different type in Schema.Resource
+				// and in the struct. Most likely those are embeded structs with Key/Value fields.
+				// the reason for keeping that that way is to simplify the terraform definition and the same time
+				// keep compatibility with the json output generated for spinnaker
+				// affected fields are tagged with `mapstructure:"-"`
+				if tag == "-" {
+					tag = strings.ToLower(field.Name)
+				}
+
+				key = fmt.Sprintf("%s.%s", prefix, tag)
+				tags[key] = field.Type.Kind().String()
+			} else {
+				key = fmt.Sprintf("%s.%s", prefix, strings.ToLower(field.Name))
+				tags[key] = field.Type.Kind().String()
+			}
+
+			switch field.Type.Kind() {
+			case reflect.Struct:
+				GetFieldTagsFromStruct(key, sourceValue.Field(i).Interface(), tagName, tags)
+			case reflect.Slice:
+				var elem reflect.Type
+
+				kind := sourceType.Field(i).Type.Elem().Kind()
+				if kind == reflect.Ptr {
+					elem = sourceType.Field(i).Type.Elem().Elem()
+				} else if kind == reflect.Interface {
+					continue
+				} else {
+					elem = sourceType.Field(i).Type.Elem()
+				}
+				indirect := reflect.Indirect(reflect.New(elem))
+				GetFieldTagsFromStruct(key, indirect.Interface(), tagName, tags)
+			}
+		}
+	}
+}
+
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	if a != b {
+		t.Fatalf("%s != %s", a, b)
+	}
+}

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -35,7 +35,8 @@ func Provider() *schema.Provider {
 			"spinnaker_pipeline_template_config": resourcePipelineTemplateConfig(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"spinnaker_pipeline": datasourcePipeline(),
+			"spinnaker_pipeline":          datasourcePipeline(),
+			"spinnaker_pipeline_document": datasourcePipelineDocument(),
 		},
 		ConfigureFunc: providerConfigureFunc,
 	}

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -13,6 +13,7 @@ func resourceApplication() *schema.Resource {
 			"application": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"email": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
PR adds spinnaker_pipeline_document data source.
- generates json pipeline from the HCL definition
- adds an option to reuse parts of the documents and merge them

The minor changes:
- adds ForceNew to resource_application when application name changes
- remove unnecessary ForceNew from the spinnaker_pipeline data sources fields