### PR TITLE
Allow user to pass default-headers to gate client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -409,7 +409,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:82a07f64fd9a0a6147392afabff000591785e10fca3860861788d3a378d05df4"
+  digest = "1:43a64bc410fac285240282d6880f3eb9081cd1aa775c6044f8a21ffec29c58c1"
   name = "github.com/spinnaker/spin"
   packages = [
     "cmd/gateclient",
@@ -417,6 +417,7 @@
     "config",
     "config/auth",
     "config/auth/basic",
+    "config/auth/googleserviceaccount",
     "config/auth/iap",
     "config/auth/oauth2",
     "config/auth/x509",
@@ -426,7 +427,7 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "dc900bc5b869e8d563bae25faf14826174576b2b"
+  revision = "0d47b8bdc7e75cc1df033944baa99a9678ac463c"
 
 [[projects]]
   digest = "1:db345c377984d0907323c09a9b17f11d995a59649fd38f909727df358b5f9020"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ provider "spinnaker" {
     server             = "http://spinnaker-gate.myorg.io"
     config             = "/path/to/config.yml"
     ignore_cert_errors = true
+    default_headers    = "Api-Key=abc123"
 }
 ```
 
@@ -61,7 +62,7 @@ provider "spinnaker" {
 * `server` - The Gate API Url
 * `config` - (Optional) - Path to Gate config file. See the [Spin CLI](https://github.com/spinnaker/spin/blob/master/config/example.yaml) for an example config.
 * `ignore_cert_errors` - (Optional) - Set this to `true` to ignore certificate errors from Gate. Defaults to `false`.
-
+* `default_headers` - (Optional) - Pass through a comma separated set of key value pairs to set default headers for the gate client when sending requests to your gate endpoint e.g. "header1=value1,header2=value2". Defaults to "".
 
 ## Resources
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/MarkFreebairn/terraform-provider-spinnaker/spinnaker"
+	"github.com/armory-io/terraform-provider-spinnaker/spinnaker"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 )

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/armory-io/terraform-provider-spinnaker/spinnaker"
+	"github.com/MarkFreebairn/terraform-provider-spinnaker/spinnaker"
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
 )

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -27,6 +27,12 @@ func Provider() *schema.Provider {
 				Description: "Ignore certificate errors from Gate",
 				Default:     false,
 			},
+			"default_headers": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Headers to be passed to the gate endpoint by the client on each request",
+				Default:     "",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"spinnaker_application":              resourceApplication(),
@@ -50,6 +56,7 @@ func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	server := data.Get("server").(string)
 	config := data.Get("config").(string)
 	ignore_cert_errors := data.Get("ignore_cert_errors").(bool)
+	default_headers := data.Get("default_headers").(string)
 
 	flags := pflag.NewFlagSet("default", 1)
 	flags.String("gate-endpoint", server, "")
@@ -58,6 +65,7 @@ func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	flags.Bool("no-color", true, "")
 	flags.String("output", "", "")
 	flags.String("config", config, "")
+	flags.String("default-headers", default_headers, "")
 	// flags.Parse()
 	client, err := gate.NewGateClient(flags)
 	if err != nil {


### PR DESCRIPTION
This PR provides solution for #22 

This allows user to set the new `default-headers` flag that was added as part of this PR https://github.com/spinnaker/spin/pull/182 

This has been built and tested both hitting a locally running gate api with no headers, as well as gate exposed via an api gateway passing through authentication header. 