### PR TITLE
fix(spin): Add default-headers flag for spinnaker/spin

### DIFF
--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -52,6 +52,7 @@ func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	ignoreCertErrors := data.Get("ignore_cert_errors").(bool)
 
 	flags := pflag.NewFlagSet("default", 1)
+	flags.String("default-headers", "", "")
 	flags.String("gate-endpoint", server, "")
 	flags.Bool("quiet", false, "")
 	flags.Bool("insecure", ignoreCertErrors, "")


### PR DESCRIPTION
Missed this in updating the spin dependency. There's a new flag, so
this needs to be added for its sake.

This is not yet exposed by the provider so it can be determined if the
provider should do that or if a config file is necessary.