### PR TITLE
feat(provider): allow user to pass default-headers to gate client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ provider "spinnaker" {
     server             = "http://spinnaker-gate.myorg.io"
     config             = "/path/to/config.yml"
     ignore_cert_errors = true
+    default_headers    = "Api-Key=abc123"
 }
 ```
 
@@ -60,7 +61,7 @@ provider "spinnaker" {
 * `server` - The Gate API Url
 * `config` - (Optional) - Path to Gate config file. See the [Spin CLI](https://github.com/spinnaker/spin/blob/master/config/example.yaml) for an example config.
 * `ignore_cert_errors` - (Optional) - Set this to `true` to ignore certificate errors from Gate. Defaults to `false`.
-
+* `default_headers` - (Optional) - Pass through a comma separated set of key value pairs to set default headers for the gate client when sending requests to your gate endpoint e.g. "header1=value1,header2=value2". Defaults to "".
 
 ## Resources
 

--- a/spinnaker/provider.go
+++ b/spinnaker/provider.go
@@ -27,6 +27,12 @@ func Provider() *schema.Provider {
 				Description: "Ignore certificate errors from Gate",
 				Default:     false,
 			},
+			"default_headers": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Headers to be passed to the gate endpoint by the client on each request",
+				Default:     "",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"spinnaker_application":              resourceApplication(),
@@ -50,6 +56,7 @@ func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	server := data.Get("server").(string)
 	config := data.Get("config").(string)
 	ignoreCertErrors := data.Get("ignore_cert_errors").(bool)
+	defaultHeaders := data.Get("default_headers").(string)
 
 	flags := pflag.NewFlagSet("default", 1)
 	flags.String("gate-endpoint", server, "")
@@ -58,6 +65,7 @@ func providerConfigureFunc(data *schema.ResourceData) (interface{}, error) {
 	flags.Bool("no-color", true, "")
 	flags.String("output", "", "")
 	flags.String("config", config, "")
+	flags.String("default-headers", defaultHeaders, "")
 	// flags.Parse()
 	client, err := gate.NewGateClient(flags)
 	if err != nil {


### PR DESCRIPTION
This PR is submitted to resolve merge conflicts under #23 (closes #23).

Also fixes the spin upgrade without adding default-headers (#26).

Co-Authored-By: Noel Cower <ncower@gmail.com>