### PR TITLE
Apache thrift fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,3 +12,5 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/spinnaker/spin v0.0.0-20190530150642-535d2dc1b985
 )
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	cloud.google.com/go v0.37.4 // indirect
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/terraform v0.12.0
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,7 +8,6 @@ dmitri.shuralyov.com/app/changes v0.0.0-20180602232624-0a106ad413e3/go.mod h1:Yl
 dmitri.shuralyov.com/html/belt v0.0.0-20180602232347-f7d459c86be0/go.mod h1:JLBrvjyP0v+ecvNYvCpyZgu5/xkfAUhi6wJj28eUfSU=
 dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1:a1inKt/atXimZ4Mv927x+r7UpyzRUf4emIoiiSC2TN4=
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
-git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/Azure/azure-sdk-for-go v21.3.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.15.4+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
@@ -27,6 +26,7 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antchfx/xpath v0.0.0-20190129040759-c8489ed3251e/go.mod h1:Yee4kTMuNiPYJ7nSNorELQMr1J33uOpXDMByNYhvtNk=
 github.com/antchfx/xquery v0.0.0-20180515051857-ad5b8c7a47b0/go.mod h1:LzD22aAzDP8/dyiCKFp31He4m2GPjl0AFyzDtZzUu9M=
+github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apparentlymart/go-cidr v1.0.0 h1:lGDvXx8Lv9QHjrAVP7jyzleG4F9+FkRhJcEsDFxeb8w=
 github.com/apparentlymart/go-cidr v1.0.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20161106042343-c914be64f07d/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
 	"net/http"
 	"strings"
 	"time"
@@ -31,12 +32,16 @@ func GetApplication(client *gate.GatewayClient, applicationName string, dest int
 	return nil
 }
 
-func CreateApplication(client *gate.GatewayClient, applicationName, email string) error {
+func CreateApplication(client *gate.GatewayClient, applicationData *schema.ResourceData) error {
+	applicationName := applicationData.Get("application").(string)
 
 	app := map[string]interface{}{
-		"instancePort": 80,
-		"name":         applicationName,
-		"email":        email,
+		"instancePort":   80,
+		"name":           applicationName,
+		"email":          applicationData.Get("email").(string),
+		"repoType":       applicationData.Get("repo_type").(string),
+		"repoProjectKey": applicationData.Get("repo_project_key").(string),
+		"repoSlug":       applicationData.Get("repo_slug").(string),
 	}
 
 	createAppTask := map[string]interface{}{

--- a/spinnaker/api/application.go
+++ b/spinnaker/api/application.go
@@ -12,7 +12,10 @@ import (
 )
 
 func GetApplication(client *gate.GatewayClient, applicationName string, dest interface{}) error {
-	app, resp, err := client.ApplicationControllerApi.GetApplicationUsingGET(client.Context, applicationName, map[string]interface{}{})
+	app, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.ApplicationControllerApi.GetApplicationUsingGET(client.Context, applicationName, map[string]interface{}{})
+	})
+
 	if resp != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Application '%s' not found\n", applicationName)
@@ -34,7 +37,6 @@ func GetApplication(client *gate.GatewayClient, applicationName string, dest int
 
 func CreateApplication(client *gate.GatewayClient, applicationData *schema.ResourceData) error {
 	applicationName := applicationData.Get("application").(string)
-
 	app := map[string]interface{}{
 		"instancePort":   80,
 		"name":           applicationName,
@@ -50,7 +52,10 @@ func CreateApplication(client *gate.GatewayClient, applicationData *schema.Resou
 		"description": fmt.Sprintf("Create Application: %s", applicationName),
 	}
 
-	ref, _, err := client.TaskControllerApi.TaskUsingPOST1(client.Context, createAppTask)
+	ref, _, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.TaskControllerApi.TaskUsingPOST1(client.Context, createAppTask)
+	})
+
 	if err != nil {
 		return err
 	}
@@ -58,13 +63,18 @@ func CreateApplication(client *gate.GatewayClient, applicationData *schema.Resou
 	toks := strings.Split(ref["ref"].(string), "/")
 	id := toks[len(toks)-1]
 
-	task, resp, err := client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+	task, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+	})
+
 	attempts := 0
 	for (task == nil || !taskCompleted(task)) && attempts < 5 {
 		toks := strings.Split(ref["ref"].(string), "/")
 		id := toks[len(toks)-1]
 
-		task, resp, err = client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+		task, resp, err = retry(func() (map[string]interface{}, *http.Response, error) {
+			return client.TaskControllerApi.GetTaskUsingGET1(client.Context, id)
+		})
 		attempts += 1
 		time.Sleep(time.Duration(attempts*attempts) * time.Second)
 	}
@@ -96,7 +106,9 @@ func DeleteAppliation(client *gate.GatewayClient, applicationName string) error 
 		"description": fmt.Sprintf("Delete Application: %s", applicationName),
 	}
 
-	_, resp, err := client.TaskControllerApi.TaskUsingPOST1(client.Context, deleteAppTask)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.TaskControllerApi.TaskUsingPOST1(client.Context, deleteAppTask)
+	})
 
 	if err != nil {
 		return err

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -9,7 +9,11 @@ import (
 )
 
 func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
-	resp, err := client.PipelineControllerApi.SavePipelineUsingPOST(client.Context, pipeline)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		resp, err := client.PipelineControllerApi.SavePipelineUsingPOST(client.Context, pipeline)
+
+		return nil, resp, err
+	})
 
 	if err != nil {
 		return err
@@ -23,9 +27,13 @@ func CreatePipeline(client *gate.GatewayClient, pipeline interface{}) error {
 }
 
 func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName string, dest interface{}) (map[string]interface{}, error) {
-	jsonMap, resp, err := client.ApplicationControllerApi.GetPipelineConfigUsingGET(client.Context,
-		applicationName,
-		pipelineName)
+	jsonMap, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.ApplicationControllerApi.GetPipelineConfigUsingGET(
+			client.Context,
+			applicationName,
+			pipelineName,
+		)
+	})
 
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -55,7 +63,9 @@ func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName strin
 }
 
 func UpdatePipeline(client *gate.GatewayClient, pipelineID string, pipeline interface{}) error {
-	_, resp, err := client.PipelineControllerApi.UpdatePipelineUsingPUT(client.Context, pipelineID, pipeline)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.PipelineControllerApi.UpdatePipelineUsingPUT(client.Context, pipelineID, pipeline)
+	})
 
 	if err != nil {
 		return err
@@ -69,7 +79,14 @@ func UpdatePipeline(client *gate.GatewayClient, pipelineID string, pipeline inte
 }
 
 func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName string) error {
-	resp, err := client.PipelineControllerApi.DeletePipelineUsingDELETE(client.Context, applicationName, pipelineName)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		resp, err := client.PipelineControllerApi.DeletePipelineUsingDELETE(
+			client.Context,
+			applicationName,
+			pipelineName,
+		)
+		return nil, resp, err
+	})
 
 	if err != nil {
 		return err

--- a/spinnaker/api/pipeline.go
+++ b/spinnaker/api/pipeline.go
@@ -2,8 +2,10 @@ package api
 
 import (
 	"fmt"
+	"log"
 	"net/http"
-
+)
+import (
 	"github.com/mitchellh/mapstructure"
 	gate "github.com/spinnaker/spin/cmd/gateclient"
 )
@@ -39,7 +41,7 @@ func GetPipeline(client *gate.GatewayClient, applicationName, pipelineName strin
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return jsonMap, fmt.Errorf("%s", ErrCodeNoSuchEntityException)
 		}
-		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s, %s\n",
+		return jsonMap, fmt.Errorf("Encountered an error getting pipeline %s. Error: %s\n",
 			pipelineName,
 			err.Error())
 	}
@@ -95,6 +97,6 @@ func DeletePipeline(client *gate.GatewayClient, applicationName, pipelineName st
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("Encountered an error deleting pipeline, status code: %d\n", resp.StatusCode)
 	}
-
+	log.Printf("deleted pipeline %v for application %v", pipelineName, applicationName)
 	return nil
 }

--- a/spinnaker/api/retry.go
+++ b/spinnaker/api/retry.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+const (
+	// maxRetries defines the number of times an operation should be retried in
+	// the worst case.
+	maxRetries = 5
+
+	// retryInterval specified the time to wait between two retries.
+	retryInterval = 2 * time.Second
+)
+
+// operation is a func that performs an API call and returns the response json
+// data as map, the http response and an error.
+type operation func() (map[string]interface{}, *http.Response, error)
+
+// retry retries an operation using constant backoff.
+func retry(fn operation) (data map[string]interface{}, resp *http.Response, err error) {
+	err = backoff.Retry(func() error {
+		data, resp, err = fn()
+
+		// Check the response code. We retry on 500-range responses to allow
+		// the server time to recover, as 500's are typically not permanent
+		// errors and may relate to outages on the server side. This will catch
+		// invalid response codes as well, like 0 and 999.
+		if resp != nil && (resp.StatusCode == 0 || resp.StatusCode >= 500) {
+			return errors.New(http.StatusText(resp.StatusCode))
+		}
+
+		return err
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(retryInterval), maxRetries))
+
+	return
+}

--- a/spinnaker/api/template.go
+++ b/spinnaker/api/template.go
@@ -13,7 +13,12 @@ const (
 )
 
 func CreatePipelineTemplate(client *gate.GatewayClient, template interface{}) error {
-	resp, err := client.PipelineTemplatesControllerApi.CreateUsingPOST(client.Context, template)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		resp, err := client.PipelineTemplatesControllerApi.CreateUsingPOST(client.Context, template)
+
+		return nil, resp, err
+	})
+
 	if err != nil {
 		return err
 	}
@@ -26,7 +31,10 @@ func CreatePipelineTemplate(client *gate.GatewayClient, template interface{}) er
 }
 
 func GetPipelineTemplate(client *gate.GatewayClient, templateID string, dest interface{}) error {
-	successPayload, resp, err := client.PipelineTemplatesControllerApi.GetUsingGET(client.Context, templateID)
+	successPayload, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.PipelineTemplatesControllerApi.GetUsingGET(client.Context, templateID)
+	})
+
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("%s", ErrCodeNoSuchEntityException)
@@ -55,7 +63,10 @@ func GetPipelineTemplate(client *gate.GatewayClient, templateID string, dest int
 }
 
 func DeletePipelineTemplate(client *gate.GatewayClient, templateID string) error {
-	_, resp, err := client.PipelineTemplatesControllerApi.DeleteUsingDELETE(client.Context, templateID, nil)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		return client.PipelineTemplatesControllerApi.DeleteUsingDELETE(client.Context, templateID, nil)
+	})
+
 	if err != nil {
 		return err
 	}
@@ -70,7 +81,12 @@ func DeletePipelineTemplate(client *gate.GatewayClient, templateID string) error
 }
 
 func UpdatePipelineTemplate(client *gate.GatewayClient, templateID string, template interface{}) error {
-	resp, err := client.PipelineTemplatesControllerApi.UpdateUsingPOST(client.Context, templateID, template, nil)
+	_, resp, err := retry(func() (map[string]interface{}, *http.Response, error) {
+		resp, err := client.PipelineTemplatesControllerApi.UpdateUsingPOST(client.Context, templateID, template, nil)
+
+		return nil, resp, err
+	})
+
 	if err != nil {
 		return err
 	}

--- a/spinnaker/resource_application.go
+++ b/spinnaker/resource_application.go
@@ -18,6 +18,18 @@ func resourceApplication() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"repo_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"repo_slug": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"repo_project_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Create: resourceApplicationCreate,
 		Read:   resourceApplicationRead,
@@ -30,21 +42,15 @@ func resourceApplication() *schema.Resource {
 type applicationRead struct {
 	Name       string `json:"name"`
 	Attributes struct {
-		Email string `json:"email"`
+		Email          string `json:"email"`
+		RepoType       string `json:"repoType"`
+		RepoProjectKey string `json:"repoProjectKey"`
+		RepoSlug       string `json:"repoSlug"`
 	} `json:"attributes"`
 }
 
 func resourceApplicationCreate(data *schema.ResourceData, meta interface{}) error {
-	clientConfig := meta.(gateConfig)
-	client := clientConfig.client
-	application := data.Get("application").(string)
-	email := data.Get("email").(string)
-
-	if err := api.CreateApplication(client, application, email); err != nil {
-		return err
-	}
-
-	return resourceApplicationRead(data, meta)
+	return upsertApplication(data, meta)
 }
 
 func resourceApplicationRead(data *schema.ResourceData, meta interface{}) error {
@@ -60,7 +66,7 @@ func resourceApplicationRead(data *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceApplicationUpdate(data *schema.ResourceData, meta interface{}) error {
-	return nil
+	return upsertApplication(data, meta)
 }
 
 func resourceApplicationDelete(data *schema.ResourceData, meta interface{}) error {
@@ -90,6 +96,17 @@ func resourceApplicationExists(data *schema.ResourceData, meta interface{}) (boo
 	}
 
 	return true, nil
+}
+
+func upsertApplication(data *schema.ResourceData, meta interface{}) error {
+	clientConfig := meta.(gateConfig)
+	client := clientConfig.client
+
+	if err := api.CreateApplication(client, data); err != nil {
+		return err
+	}
+
+	return resourceApplicationRead(data, meta)
 }
 
 func readApplication(data *schema.ResourceData, application applicationRead) error {

--- a/spinnaker/resource_pipeline.go
+++ b/spinnaker/resource_pipeline.go
@@ -147,7 +147,7 @@ func resourcePipelineExists(data *schema.ResourceData, meta interface{}) (bool, 
 	pipelineName := data.Get("name").(string)
 
 	var p pipelineRead
-	if _, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil {
+	if _, err := api.GetPipeline(client, applicationName, pipelineName, &p); err != nil && !strings.Contains(err.Error(), "EOF") {
 		return false, err
 	}
 


### PR DESCRIPTION
Since the mirror `git.apache.org` is down (https://status.apache.org/) and does not seem to come back, we will replace references to this mirror (`git.apache.org/thrift`) with the correct repository at `github.com/apache/thrift`.

This will allow us to build the provider again.